### PR TITLE
Issue 22 - Add ability to ignore routes for replayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The full list of options are as follows:
 - `verbose`: outputs extra data whenever a fixture is accessed, along with the
   parts used to create the name of the fixture.
 - `touchHits`: disable timestamp update of fixture files on a cache hit.
-- `includeHeaderNames`, `headerWhitelist`, `includeCookieNames`,
+- `includeHeaderNames`, `headerWhitelist`, `urlBlacklist`, `includeCookieNames`,
   `cookieWhitelist`: detailed in a later section.
 - 'debug': Useful for debugging the requests when there is a cache miss. If
    fixtures are recorded with debug mode true, replayer will additionally save all
@@ -268,6 +268,19 @@ Examples of this functionality can be seen in `examples/headers.js`:
 
     rm -r fixtures # in case you had previously generated fixtures
     VCR_MODE=cache node examples/headers
+
+## Ignoring Routes
+
+Some routes you might want Replayer to ignore.  For instance, if you're testing an authentication route that returns a token that expires after 15 minutes, you would not want to cache this response because the token will be invalid.  
+
+To ignore routes, add an option to your configuration like so:
+
+    var replayer = require('replayer');
+    replayer.configure({
+      urlBlacklist: [/myauthurl.com/,/otherroute/]
+    });
+
+The urlBlacklist takes and array of regular expressions to match against.  If a route matches any of these regular expressions, it will by pass the replayer and only use https/http request module.
 
 ## Hiding Sensitive Data
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -126,6 +126,14 @@ module.exports.isEnabled = function isEnabled() {
     } else {
       reqUrl = replayerUtil.urlFromHttpRequestOptions(options, protocol);
     }
+   
+    //Break out of new request module and use original request if
+    //request url matches regex pattern from global urlBlacklist
+    var shouldIgnoreUrl = replayerUtil.testUrlAgainstRegex(reqUrl);
+    if(shouldIgnoreUrl) {
+      return oldRequest(options);
+    }
+    
     var reqBody = [];
     var debug = replayerUtil.shouldFindMatchingFixtures();
 

--- a/src/util.js
+++ b/src/util.js
@@ -33,6 +33,7 @@ function reset() {
 
   globalOptions.filenameFilters = [];
   globalOptions.substitutions = [];
+  globalOptions.urlBlacklist = [];
 
   globalOptions.includeHeaderValues = false;
   globalOptions.includeHeaderNames = true;
@@ -84,6 +85,12 @@ function configure(options) {
         return item.toLowerCase();
       }
     );
+  }
+
+  if (options.urlBlacklist != null) {
+    globalOptions.urlBlacklist = options.urlBlacklist.map(function(urlRegex) {
+      return urlRegex;
+    });
   }
 
   if (options.verbose != null) {
@@ -167,6 +174,12 @@ function filterByWhitelist(list, whitelist) {
 
   return list.filter(function(item) {
     return whitelist.indexOf(item) >= 0;
+  });
+}
+
+function testUrlAgainstRegex(url) {
+  return globalOptions.urlBlacklist.some(function(regex) {
+    return regex.test(url);
   });
 }
 
@@ -472,6 +485,7 @@ module.exports.constructFilename = constructFilename;
 module.exports.urlFromHttpRequestOptions = urlFromHttpRequestOptions;
 module.exports.shouldForceLive = shouldForceLive;
 module.exports.removeInternalHeaders = removeInternalHeaders;
+module.exports.testUrlAgainstRegex = testUrlAgainstRegex;
 module.exports.findTheBestMatchingFixture = findTheBestMatchingFixture;
 module.exports.shouldFindMatchingFixtures = shouldFindMatchingFixtures;
 module.exports.addSubstitution = addSubstitution;

--- a/test/util.js
+++ b/test/util.js
@@ -1033,4 +1033,17 @@ describe('utils.js', function() {
     });
 
   });
+
+  describe('#testAgainstUrlRegex', function() {
+    it('should return true if the routes in test match the regex. False otherwise', function() {
+      replayerUtil.internal.globalOptions.urlBlacklist = [/test/,/boop/];
+      var shouldIgnoreRoute1 = replayerUtil.testUrlAgainstRegex('http://www.test.com/true');
+      var shouldIgnoreRoute2 = replayerUtil.testUrlAgainstRegex('http://www.beep.com/boop');
+      var shouldIgnoreRoute3 = replayerUtil.testUrlAgainstRegex('http://www.foo.com/bar');
+      
+      shouldIgnoreRoute1.should.equal(true);
+      shouldIgnoreRoute2.should.equal(true);
+      shouldIgnoreRoute3.should.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
Passing in an options `urlBlacklist: [/regex/]` has replayer skip recording
and go straight to the http/https module.

Updated Readme and added test